### PR TITLE
feat: ability to set state directly in effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ const wrapComponentWithState = provideState({
   initialState: () => ({ counter: 0 }),
   effects: {
     addOne: () => (state, props) => ({ ...state, counter: state.counter + 1 }),
+    async loadData () {
+      const { state } = this
+      if (state.loading) {
+        return
+      }
+      state.loading = true
+      try {
+        state.data = await (await fetch('./data.json')).json()
+      } finally {
+        state.loading = false
+      }
+    }
   },
   computed: {
     square: (state, props) => state.counter * state.counter,

--- a/src/factory.js
+++ b/src/factory.js
@@ -150,6 +150,10 @@ module.exports = ({ Component, createElement, PropTypes }) => {
                 stateDescriptors[k] = {
                   enumerable: true,
                   get: () => state[k],
+                  set: value => {
+                    state = { ...state, [k]: value }
+                    dispatch()
+                  },
                 }
               }
             })
@@ -201,13 +205,17 @@ module.exports = ({ Component, createElement, PropTypes }) => {
             }
 
             effectsDescriptors = create(null)
+            const context = {
+              effects,
+              state: completeState,
+            }
             keys(effects).forEach(k => {
               const e = effects[k]
               effectsDescriptors[k] = {
                 enumerable: true,
                 value: (...args) => {
                   try {
-                    return Promise.resolve(handleStateUpdater(e(this._effects, ...args)))
+                    return Promise.resolve(handleStateUpdater(e.call(context, this._effects, ...args)))
                   } catch (error) {
                     return Promise.reject(error)
                   }


### PR DESCRIPTION
Useful for async effects:

```js
provideState({
  initialState: () => ({
    data: undefined,
    loading: false,
  }),
  effects: {
    async loadData () {
      const { state } = this
      if (state.loading) {
        return
      }
      state.loading = true
      try {
        state.data = await fetchData()
      } finally {
        state.loading = false
      }
    }
  }
})
```

/cc @badrAZ @HamadaBrest